### PR TITLE
Add runes_asan to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ lexer.md
 lexertask.md
 err.txt
 out.txt
+runes_asan


### PR DESCRIPTION
This PR adds runes_asan to .gitignore to prevent tracking of the ASAN build binary.

Fixes #29 