### PR TITLE
fix: resolve segfault in typechecker_collect_decls when processing extern declarations (fixes #2)

### DIFF
--- a/src/tests/samples/99_extern_decl_regression.runes
+++ b/src/tests/samples/99_extern_decl_regression.runes
@@ -1,0 +1,10 @@
+-- Regression test for BUG-001: extern declarations in prelude caused segfault
+-- in typechecker_collect_decls when accessing node->as.program.declarations
+-- on a raw declarations list instead of the node itself.
+
+extern f log(msg: str)
+extern i32 MAX_BUFFER_SIZE
+
+f main() {
+    log("extern decl typecheck regression test passed")
+}

--- a/src/typecheck.c
+++ b/src/typecheck.c
@@ -300,7 +300,7 @@ Type *typechecker_resolve_type_expr(TypeChecker *tc, AstNode *node) {
 
 static void typechecker_collect_decls(TypeChecker *tc, AstNode *node) {
   // Pass 1: Types (Structs, Variants)
-  AstNode *decl = node->as.program.declarations;
+  AstNode *decl = node;
   while (decl) {
     if (decl->kind == AST_TYPE_DECL) {
       Symbol *sym = symbol_table_lookup_local(tc->st, decl->as.type_decl.name);
@@ -322,7 +322,7 @@ static void typechecker_collect_decls(TypeChecker *tc, AstNode *node) {
   }
 
   // Pass 1.5: Populate Type fields (now that all type objects exist)
-  decl = node->as.program.declarations;
+  decl = node;
   while (decl) {
     if (decl->kind == AST_TYPE_DECL) {
       Symbol *sym = symbol_table_lookup_local(tc->st, decl->as.type_decl.name);
@@ -379,7 +379,7 @@ static void typechecker_collect_decls(TypeChecker *tc, AstNode *node) {
   }
 
   // Pass 2: Functions, Externs, Variables, Methods
-  decl = node->as.program.declarations;
+  decl = node;
   while (decl) {
     if (decl->kind == AST_FUNC_DECL) {
       Symbol *sym = symbol_table_lookup_local(tc->st, decl->as.func_decl.name);


### PR DESCRIPTION
## Summary

Fixes the segfault (SIGSEGV) in `typechecker_collect_decls` that blocked all typechecker tests. The function received a declarations list from callers but incorrectly accessed `node->as.program.declarations`, causing a misaligned pointer dereference (address 0x1) when `extern` declarations were present.

## Root Cause

`typechecker_collect_decls` is called from two sites:
- `typechecker_check`: passes `program->as.program.declarations` (declarations list)
- `typechecker_check_node` for `AST_BLOCK`: passes `node->as.block.statements` (statements list)

In both cases, the parameter `node` is already the list head. But the function did `node->as.program.declarations` to initialize the loop variable, treating the list as a `AST_PROGRAM` node. When `extern` declarations are present (e.g., `src/std/prelude.runes`), this reads garbage memory and dereferences address 0x1.

## Fix

Changed all 3 occurrences of `node->as.program.declarations` to `node` inside `typechecker_collect_decls`:

1. Pass 1 (Types): `AstNode *decl = node`
2. Pass 1.5 (Populate fields): `decl = node`
3. Pass 2 (Functions, Externs, Variables): `decl = node`

## Regression Test

Added `src/tests/samples/99_extern_decl_regression.runes` that exercises extern declaration typechecking with both an extern function and extern variable.

## Verification

Before fix: `./runes src/std/prelude.runes` segfaults (SIGSEGV, exit 139)
After fix: compiles successfully, all test suite samples pass

Closes #2